### PR TITLE
add io checks

### DIFF
--- a/system/io/metrics-ioping.yml
+++ b/system/io/metrics-ioping.yml
@@ -1,0 +1,128 @@
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: metrics-ioping
+  namespace: default
+spec:
+  command: metrics-ioping.rb
+  interval: 10
+  publish: true
+  runtime_assets:
+  - sensu-plugins/sensu-plugins-io-checks
+  - sensu/sensu-ruby-runtime
+  subscriptions:
+  - io
+  handlers:
+  - alert
+---
+type: Asset
+api_version: core/v2
+metadata:
+  annotations:
+    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu-plugins/sensu-plugins-io-checks
+    io.sensu.bonsai.name: sensu-plugins-io-checks
+    io.sensu.bonsai.namespace: sensu-plugins
+    io.sensu.bonsai.tags: ruby-runtime-2.4.4
+    io.sensu.bonsai.tier: Community
+    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-io-checks
+    io.sensu.bonsai.version: 3.0.0
+  name: sensu-plugins/sensu-plugins-io-checks
+  namespace: default
+spec:
+  builds:
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    headers: null
+    sha512: 0f32be0e336e610007775a2688cde8eebd774a408688db36c46a56a23c175988b2eb5925841a986f70ad70c6da7874cdfd0c3f1593f04f1674d5c365b7dfaaaa
+    url: https://assets.bonsai.sensu.io/ef9ea12f32e697279b471d5016ced51de39d8ddb/sensu-plugins-io-checks_3.0.0_debian9_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform_family == 'debian'
+    headers: null
+    sha512: f8cd5abc211e7b6a395f7d35422ccb4e589bc5a75745d448bb2579b1b4c303b27ceb7abcfeb1c66caa8791dcbdd181069e3a051850df3b6ed40018f8161f52c6
+    url: https://assets.bonsai.sensu.io/ef9ea12f32e697279b471d5016ced51de39d8ddb/sensu-plugins-io-checks_3.0.0_debian_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform_family == 'rhel'
+    - entity.system.platform_version.split('.')[0] == '7'
+    headers: null
+    sha512: 12961fdb73d1a5ca5ba112bd558e388ab02f22a4e3aa8f8cffca0653e0e3a763a6e2e4b541614722b2eb4ad84f567bd0f8479fadc3c4b7e4b699f48d89bd7f82
+    url: https://assets.bonsai.sensu.io/ef9ea12f32e697279b471d5016ced51de39d8ddb/sensu-plugins-io-checks_3.0.0_centos7_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform_family == 'rhel'
+    - entity.system.platform_version.split('.')[0] == '6'
+    headers: null
+    sha512: 1190cef1200f79e7f19fbcbd9f7d28db2057ec1890030cdced3f60a3f353d89e441ec2b183d17b399a377470de81a6aebf3d5dfe5374b7d066348ca8252800c4
+    url: https://assets.bonsai.sensu.io/ef9ea12f32e697279b471d5016ced51de39d8ddb/sensu-plugins-io-checks_3.0.0_centos6_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform == 'alpine'
+    headers: null
+    sha512: bb5a2d5027b9faaaa4504b46514a49b79d9ecb613df7680a8c4242f4403b6665f1dcc43416ac35912c5cfdb66aff94038e72716c4f8655e78d42f34551723531
+    url: https://assets.bonsai.sensu.io/ef9ea12f32e697279b471d5016ced51de39d8ddb/sensu-plugins-io-checks_3.0.0_alpine3.8_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform == 'alpine'
+    - entity.system.platform_version.split('.')[0] == '3'
+    headers: null
+    sha512: a8cd36ba5801b42f6a75fdfca7a3e260c2eff8d2bd26aae5941b9a63101c9ba4b44a368191548e7df68bf6ec1443c3717d43bb8d1cfcf8f48a5c529d385703c4
+    url: https://assets.bonsai.sensu.io/ef9ea12f32e697279b471d5016ced51de39d8ddb/sensu-plugins-io-checks_3.0.0_alpine_linux_amd64.tar.gz
+  filters: null
+  headers: null
+---
+type: Asset
+api_version: core/v2
+metadata:
+  annotations:
+    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-ruby-runtime
+    io.sensu.bonsai.name: sensu-ruby-runtime
+    io.sensu.bonsai.namespace: sensu
+    io.sensu.bonsai.tags: ""
+    io.sensu.bonsai.tier: Community
+    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
+    io.sensu.bonsai.version: 0.0.10
+  name: sensu/sensu-ruby-runtime
+  namespace: default
+spec:
+  builds:
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform_family == 'rhel'
+    - parseInt(entity.system.platform_version.split('.')[0]) == 6
+    headers: null
+    sha512: cbee19124b7007342ce37ff9dfd4a1dde03beb1e87e61ca2aef606a7ad3c9bd0bba4e53873c07afa5ac46b0861967a9224511b4504dadb1a5e8fb687e9495304
+    url: https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos6_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform_family == 'debian'
+    headers: null
+    sha512: a28952fd93fc63db1f8988c7bc40b0ad815eb9f35ef7317d6caf5d77ecfbfd824a9db54184400aa0c81c29b34cb48c7e8c6e3f17891aaf84cafa3c134266a61a
+    url: https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.10_ruby-2.4.4_debian_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform_family == 'rhel'
+    - parseInt(entity.system.platform_version.split('.')[0]) > 6
+    headers: null
+    sha512: 338b88b568a3213fa234640da2e037d1487fc3c639bc62340f2fb71eac8af9a90566cffc768d15035406ac5c049350006d73f3a07ae15f9528e1c6a9af2944cb
+    url: https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform == 'alpine'
+    - entity.system.platform_version.split('.')[0] == '3'
+    headers: null
+    sha512: 8d768d1fba545898a8d09dca603457eb0018ec6829bc5f609a1ea51a2be0c4b2d13e1aa46139ecbb04873449e4c76f463f0bdfbaf2107caf37ab1c8db87d5250
+    url: https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.10_ruby-2.4.4_alpine_linux_amd64.tar.gz
+  filters: null
+  headers: null

--- a/system/io/metrics-ioping.yml
+++ b/system/io/metrics-ioping.yml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-ioping
   namespace: default
 spec:
-  command: metrics-ioping.rb
+  command: metrics-ioping.rb -d /tmp -n tmp
   interval: 10
   publish: true
   runtime_assets:
@@ -13,8 +13,9 @@ spec:
   - sensu/sensu-ruby-runtime
   subscriptions:
   - io
-  handlers:
-  - alert
+  output_metric_format: graphite_plaintext
+  output_metric_handlers:
+  - metric-storage
 ---
 type: Asset
 api_version: core/v2

--- a/system/io/metrics-ioping.yml
+++ b/system/io/metrics-ioping.yml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-ioping
   namespace: default
 spec:
-  command: metrics-ioping.rb -d /tmp -n tmp
+  command: metrics-ioping.rb -d {{ .labels.metrics_ioping_directory | default /tmp }} -n {{ .labels.metrics_ioping_name | default tmp }}
   interval: 10
   publish: true
   runtime_assets:

--- a/system/io/metrics-iostat-extended.yml
+++ b/system/io/metrics-iostat-extended.yml
@@ -1,0 +1,128 @@
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: metrics-iostat-extended
+  namespace: default
+spec:
+  command: metrics-iostat-extended.rb
+  interval: 10
+  publish: true
+  runtime_assets:
+  - sensu-plugins/sensu-plugins-io-checks
+  - sensu/sensu-ruby-runtime
+  subscriptions:
+  - io
+  handlers:
+  - alert
+---
+type: Asset
+api_version: core/v2
+metadata:
+  annotations:
+    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu-plugins/sensu-plugins-io-checks
+    io.sensu.bonsai.name: sensu-plugins-io-checks
+    io.sensu.bonsai.namespace: sensu-plugins
+    io.sensu.bonsai.tags: ruby-runtime-2.4.4
+    io.sensu.bonsai.tier: Community
+    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu-plugins/sensu-plugins-io-checks
+    io.sensu.bonsai.version: 3.0.0
+  name: sensu-plugins/sensu-plugins-io-checks
+  namespace: default
+spec:
+  builds:
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    headers: null
+    sha512: 0f32be0e336e610007775a2688cde8eebd774a408688db36c46a56a23c175988b2eb5925841a986f70ad70c6da7874cdfd0c3f1593f04f1674d5c365b7dfaaaa
+    url: https://assets.bonsai.sensu.io/ef9ea12f32e697279b471d5016ced51de39d8ddb/sensu-plugins-io-checks_3.0.0_debian9_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform_family == 'debian'
+    headers: null
+    sha512: f8cd5abc211e7b6a395f7d35422ccb4e589bc5a75745d448bb2579b1b4c303b27ceb7abcfeb1c66caa8791dcbdd181069e3a051850df3b6ed40018f8161f52c6
+    url: https://assets.bonsai.sensu.io/ef9ea12f32e697279b471d5016ced51de39d8ddb/sensu-plugins-io-checks_3.0.0_debian_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform_family == 'rhel'
+    - entity.system.platform_version.split('.')[0] == '7'
+    headers: null
+    sha512: 12961fdb73d1a5ca5ba112bd558e388ab02f22a4e3aa8f8cffca0653e0e3a763a6e2e4b541614722b2eb4ad84f567bd0f8479fadc3c4b7e4b699f48d89bd7f82
+    url: https://assets.bonsai.sensu.io/ef9ea12f32e697279b471d5016ced51de39d8ddb/sensu-plugins-io-checks_3.0.0_centos7_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform_family == 'rhel'
+    - entity.system.platform_version.split('.')[0] == '6'
+    headers: null
+    sha512: 1190cef1200f79e7f19fbcbd9f7d28db2057ec1890030cdced3f60a3f353d89e441ec2b183d17b399a377470de81a6aebf3d5dfe5374b7d066348ca8252800c4
+    url: https://assets.bonsai.sensu.io/ef9ea12f32e697279b471d5016ced51de39d8ddb/sensu-plugins-io-checks_3.0.0_centos6_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform == 'alpine'
+    headers: null
+    sha512: bb5a2d5027b9faaaa4504b46514a49b79d9ecb613df7680a8c4242f4403b6665f1dcc43416ac35912c5cfdb66aff94038e72716c4f8655e78d42f34551723531
+    url: https://assets.bonsai.sensu.io/ef9ea12f32e697279b471d5016ced51de39d8ddb/sensu-plugins-io-checks_3.0.0_alpine3.8_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform == 'alpine'
+    - entity.system.platform_version.split('.')[0] == '3'
+    headers: null
+    sha512: a8cd36ba5801b42f6a75fdfca7a3e260c2eff8d2bd26aae5941b9a63101c9ba4b44a368191548e7df68bf6ec1443c3717d43bb8d1cfcf8f48a5c529d385703c4
+    url: https://assets.bonsai.sensu.io/ef9ea12f32e697279b471d5016ced51de39d8ddb/sensu-plugins-io-checks_3.0.0_alpine_linux_amd64.tar.gz
+  filters: null
+  headers: null
+---
+type: Asset
+api_version: core/v2
+metadata:
+  annotations:
+    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-ruby-runtime
+    io.sensu.bonsai.name: sensu-ruby-runtime
+    io.sensu.bonsai.namespace: sensu
+    io.sensu.bonsai.tags: ""
+    io.sensu.bonsai.tier: Community
+    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-ruby-runtime
+    io.sensu.bonsai.version: 0.0.10
+  name: sensu/sensu-ruby-runtime
+  namespace: default
+spec:
+  builds:
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform_family == 'rhel'
+    - parseInt(entity.system.platform_version.split('.')[0]) == 6
+    headers: null
+    sha512: cbee19124b7007342ce37ff9dfd4a1dde03beb1e87e61ca2aef606a7ad3c9bd0bba4e53873c07afa5ac46b0861967a9224511b4504dadb1a5e8fb687e9495304
+    url: https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos6_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform_family == 'debian'
+    headers: null
+    sha512: a28952fd93fc63db1f8988c7bc40b0ad815eb9f35ef7317d6caf5d77ecfbfd824a9db54184400aa0c81c29b34cb48c7e8c6e3f17891aaf84cafa3c134266a61a
+    url: https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.10_ruby-2.4.4_debian_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform_family == 'rhel'
+    - parseInt(entity.system.platform_version.split('.')[0]) > 6
+    headers: null
+    sha512: 338b88b568a3213fa234640da2e037d1487fc3c639bc62340f2fb71eac8af9a90566cffc768d15035406ac5c049350006d73f3a07ae15f9528e1c6a9af2944cb
+    url: https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.10_ruby-2.4.4_centos_linux_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    - entity.system.platform == 'alpine'
+    - entity.system.platform_version.split('.')[0] == '3'
+    headers: null
+    sha512: 8d768d1fba545898a8d09dca603457eb0018ec6829bc5f609a1ea51a2be0c4b2d13e1aa46139ecbb04873449e4c76f463f0bdfbaf2107caf37ab1c8db87d5250
+    url: https://assets.bonsai.sensu.io/5123017d3dadf2067fa90fc28275b92e9b586885/sensu-ruby-runtime_0.0.10_ruby-2.4.4_alpine_linux_amd64.tar.gz
+  filters: null
+  headers: null

--- a/system/io/metrics-iostat-extended.yml
+++ b/system/io/metrics-iostat-extended.yml
@@ -13,8 +13,9 @@ spec:
   - sensu/sensu-ruby-runtime
   subscriptions:
   - io
-  handlers:
-  - alert
+  output_metric_format: graphite_plaintext
+  output_metric_handlers:
+  - metric-storage
 ---
 type: Asset
 api_version: core/v2


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

```
The iostat command must be installed. On Debian/Redhat systems iostat is part of the sysstat package.
```